### PR TITLE
Update package.json to add resolutions for axios dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,9 @@
   "devDependencies": {
     "matchstick-as": "0.6.0",
     "mustache": "^4.2.0"
+  },
+  "resolutions": {
+    "axios@1.14.1": "1.13.2",
+    "axios@0.30.4": "0.21.4"
   }
 }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                       
  - Adds yarn `resolutions` to pin compromised axios versions (`1.14.1` → `1.13.2`, `0.30.4` → `0.21.4`) as a precaution against the recent axios supply chain attack                                              
           